### PR TITLE
Broken Markdown Link

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ There are many excellent tools, metrics and docs regarding page speed, but these
 
 An early beta is live and can be tried here: 
 
-[g.co/perfgame](g.co/perfgame):
+[g.co/perfgame](https://g.co/perfgame):
 
 
 


### PR DESCRIPTION
The link in the README currently leads to a 404 page when clicked via GitHub. This is due to the link missing a protocol, causing the URL to incorrectly point to https://github.com/GoogleChromeLabs/performance-game/blob/master/g.co/perfgame. This fix addresses the issue.